### PR TITLE
Make `/new` endpoint consistent with what dashboard expects

### DIFF
--- a/api/new.rs
+++ b/api/new.rs
@@ -119,7 +119,7 @@ pub async fn handler(req: Request) -> Result<Response<Body>, Error> {
                 .header("Content-Type", "application/json")
                 .body(
                     json!({
-                      "passportNumber": passport_id
+                      "id": passport_id
                     })
                     .to_string()
                     .into(),

--- a/api/new.rs
+++ b/api/new.rs
@@ -89,7 +89,7 @@ pub async fn handler(req: Request) -> Result<Response<Body>, Error> {
                 .await?;
 
             let passport_id = match latest_passport {
-                Some(mut found_passport) => if passport.activated {
+                Some(mut found_passport) => if found_passport.activated {
                     let new_passport = create_new_passport(&db, &user, new).await?;
                     new_passport.id
                 } else {

--- a/api/new.rs
+++ b/api/new.rs
@@ -1,10 +1,10 @@
 use std::str::FromStr;
 
-use entity::{passport, prelude::*, sea_orm_active_enums::RoleEnum, user};
+use entity::{passport::{self}, prelude::*, sea_orm_active_enums::RoleEnum, user};
 use id::{db, wrap_error};
 use rand::distributions::{Alphanumeric, DistString};
-use sea_orm::{prelude::*, ActiveValue};
-use vercel_runtime::{run, Body, Error, Request, Response, StatusCode};
+use sea_orm::{prelude::*, ActiveValue, IntoActiveModel, QueryOrder};
+use vercel_runtime::{run, Body, Error, Request, Response};
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
@@ -22,6 +22,25 @@ struct NewPassport {
 }
 
 const CURRENT_PASSPORT_VERSION: i32 = 0;
+
+async fn create_new_passport(db: &DatabaseConnection, user: &user::Model, new: NewPassport) -> Result<passport::Model, Error> {
+    let passport = passport::ActiveModel {
+        id: ActiveValue::NotSet,
+        owner_id: ActiveValue::Set(user.id),
+        name: ActiveValue::Set(new.name),
+        surname: ActiveValue::Set(new.surname),
+        date_of_birth: ActiveValue::Set(ChronoDate::from_str(&new.date_of_birth)?),
+        date_of_issue: ActiveValue::Set(ChronoDate::from_str(&new.date_of_issue)?),
+        place_of_origin: ActiveValue::Set(new.place_of_origin),
+        version: ActiveValue::Set(CURRENT_PASSPORT_VERSION),
+        activated: ActiveValue::Set(false),
+        secret: ActiveValue::Set(Alphanumeric.sample_string(&mut rand::thread_rng(), 32)),
+    };
+
+    let new_passport = passport.insert(db).await?;
+
+    Ok(new_passport)
+}
 
 pub async fn handler(req: Request) -> Result<Response<Body>, Error> {
     match req.body() {
@@ -53,22 +72,40 @@ pub async fn handler(req: Request) -> Result<Response<Body>, Error> {
                 }
             };
 
-            let passport = passport::ActiveModel {
-                id: ActiveValue::NotSet,
-                owner_id: ActiveValue::Set(user.id),
-                name: ActiveValue::Set(new.name),
-                surname: ActiveValue::Set(new.surname),
-                date_of_birth: ActiveValue::Set(ChronoDate::from_str(&new.date_of_birth)?),
-                date_of_issue: ActiveValue::Set(ChronoDate::from_str(&new.date_of_issue)?),
-                place_of_origin: ActiveValue::Set(new.place_of_origin),
-                version: ActiveValue::Set(CURRENT_PASSPORT_VERSION),
-                activated: ActiveValue::Set(false),
-                secret: ActiveValue::Set(Alphanumeric.sample_string(&mut rand::thread_rng(), 32)),
+            let latest_passport = Passport::find()
+                .filter(passport::Column::OwnerId.eq(user.id))
+                .order_by_desc(passport::Column::Id)
+                .one(&db)
+                .await?;
+
+            let passport_id = match latest_passport {
+                Some(passport) if passport.activated => {
+                    let new_passport = create_new_passport(&db, &user, new).await?;
+                    new_passport.id
+                }
+                _ => {
+                    if let Some(mut found_passport) = latest_passport {
+                        found_passport.name = new.name;
+                        found_passport.surname = new.surname;
+                        found_passport.date_of_birth = ChronoDate::from_str(&new.date_of_birth)?;
+                        found_passport.date_of_issue = ChronoDate::from_str(&new.date_of_issue)?;
+                        found_passport.place_of_origin = new.place_of_origin;
+                        found_passport.activated = false;
+                        found_passport.secret = Alphanumeric.sample_string(&mut rand::thread_rng(), 32);
+
+                        let active_passport = found_passport.into_active_model();
+                        let updated_passport = active_passport.update(&db).await?;
+
+                        updated_passport.id
+                    } else {
+                        let new_passport = create_new_passport(&db, &user, new).await?;
+                        new_passport.id
+                    }
+                }
             };
 
-            passport.insert(&db).await?;
-
-            Ok(Response::new(Body::Empty))
+            let response_body = serde_json::to_string(&passport_id)?;
+            Ok(Response::new(Body::Text(response_body)))
         }
     }
 }


### PR DESCRIPTION
- Update passport if a latest passport exists and is marked inactive, create otherwise
- Return the passport number (id) in the response body

I'm still very bad at Rust so feel free to change whatever makes sense. I have not yet tested my changes so I'm not actually sure if they even work.