### PR TITLE
Fix database not updating when modifying existing passport

### DIFF
--- a/api/new.rs
+++ b/api/new.rs
@@ -119,11 +119,11 @@ pub async fn handler(req: Request) -> Result<Response<Body>, Error> {
                     } else {
                         let mut active_passport = found_passport.into_active_model();
 
-                        active_passport.name = ActiveValue::Set(new.name.clone());
-                        active_passport.surname = ActiveValue::Set(new.surname.clone());
+                        active_passport.name = ActiveValue::Set(new.name);
+                        active_passport.surname = ActiveValue::Set(new.surname);
                         active_passport.date_of_birth = ActiveValue::Set(parse_date(&new.date_of_birth)?);
                         active_passport.date_of_issue = ActiveValue::Set(parse_date(&new.date_of_issue)?);
-                        active_passport.place_of_origin = ActiveValue::Set(new.place_of_origin.clone());
+                        active_passport.place_of_origin = ActiveValue::Set(new.place_of_origin);
                         active_passport.ceremony_time = ActiveValue::Set(parse_datetime(&new.ceremony_time)?);
 
                         let updated_passport = active_passport.update(&db).await?;


### PR DESCRIPTION
In `api/new`, if the user was modifying an existing passport, the `found_passport` was being modified, but the active value on the model was not being set for the updated values, so `.update()` was being called with old values. This PR updates the new values on the active model instead of the existing `found_passport` model.

I have tested against staging and verified this code works for every field.

I think this bug has been here since `id` was first created, but we never caught it because the data pages updated correctly and they were our source of truth anyway. But now that people can register for new ceremony dates, and change the ceremony date they register for, we need the values to actually update in the database, so this bug was surfaced.

Because this bug has been here for so long, it's possible some people may have info in the database that does not match the info on their actual passport. If we care about this, a human will need to spend some time combing through all the passports and checking their data against the values in the database.