### PR TITLE
Add OAuth issuer and subject fields

### DIFF
--- a/api/user.rs
+++ b/api/user.rs
@@ -6,6 +6,8 @@ use vercel_runtime::{run, Body, Error, Request, Response};
 
 #[derive(Serialize, Deserialize)]
 struct UserWithPassport {
+    iss: String,
+    sub: i32,
     id: i32,
     discord_id: i64,
     role: RoleEnum,
@@ -35,6 +37,8 @@ pub async fn handler(req: Request) -> Result<Response<Body>, Error> {
         .await?;
 
     let response_data = UserWithPassport {
+        iss: "https://id.purduehackers.com".to_owned(),
+        sub: user.id,
         id: user.id,
         discord_id: user.discord_id.clone(),
         role: user.role.clone(),

--- a/pages/authorize.tsx
+++ b/pages/authorize.tsx
@@ -8,7 +8,7 @@ enum AuthState {
   NoClient,
 }
 
-const validClients = ["dashboard", "passports", "authority", "auth-test"];
+const validClients = ["dashboard", "passports", "authority", "auth-test", "vulcan-auth", "shad-moe"];
 
 export default function Authorize({
   isValidClientId,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,7 +198,7 @@ impl WebRequest for RequestCompat {
     }
 }
 
-pub const VALID_CLIENTS: [&str; 4] = ["dashboard", "passports", "authority", "auth-test"];
+pub const VALID_CLIENTS: [&str; 5] = ["dashboard", "passports", "authority", "auth-test", "vulcan-auth", "shad-moe"]
 
 pub fn client_registry() -> ClientMap {
     let mut clients = ClientMap::new();
@@ -228,6 +228,24 @@ pub fn client_registry() -> ClientMap {
         VALID_CLIENTS[3],
         RegisteredUrl::Semantic(
             Url::from_str("https://id-auth.purduehackers.com/api/auth/callback/purduehackers-id")
+                .expect("url to be valid"),
+        ),
+        "user:read user".parse().expect("scopes to be valid"),
+    ));
+
+    clients.register_client(Client::public(
+        VALID_CLIENTS[4],
+        RegisteredUrl::Semantic(
+            Url::from_str("https://auth.purduehackers.com/source/oauth/callback/purduehackers-id")
+                .expect("url to be valid"),
+        ),
+        "user:read user".parse().expect("scopes to be valid"),
+    ));
+
+    clients.register_client(Client::public(
+        VALID_CLIENTS[5],
+        RegisteredUrl::Semantic(
+            Url::from_str("https://auth.shad.moe/source/oauth/callback/purduehackers-id")
                 .expect("url to be valid"),
         ),
         "user:read user".parse().expect("scopes to be valid"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,7 +198,7 @@ impl WebRequest for RequestCompat {
     }
 }
 
-pub const VALID_CLIENTS: [&str; 5] = ["dashboard", "passports", "authority", "auth-test", "vulcan-auth", "shad-moe"];
+pub const VALID_CLIENTS: [&str; 6] = ["dashboard", "passports", "authority", "auth-test", "vulcan-auth", "shad-moe"];
 
 pub fn client_registry() -> ClientMap {
     let mut clients = ClientMap::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,7 +198,7 @@ impl WebRequest for RequestCompat {
     }
 }
 
-pub const VALID_CLIENTS: [&str; 5] = ["dashboard", "passports", "authority", "auth-test", "vulcan-auth", "shad-moe"]
+pub const VALID_CLIENTS: [&str; 5] = ["dashboard", "passports", "authority", "auth-test", "vulcan-auth", "shad-moe"];
 
 pub fn client_registry() -> ClientMap {
     let mut clients = ClientMap::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,7 +236,7 @@ pub fn client_registry() -> ClientMap {
     clients.register_client(Client::public(
         VALID_CLIENTS[4],
         RegisteredUrl::Semantic(
-            Url::from_str("https://auth.purduehackers.com/source/oauth/callback/purduehackers-id")
+            Url::from_str("https://auth.purduehackers.com/source/oauth/callback/purduehackers-id/")
                 .expect("url to be valid"),
         ),
         "user:read user".parse().expect("scopes to be valid"),
@@ -245,7 +245,7 @@ pub fn client_registry() -> ClientMap {
     clients.register_client(Client::public(
         VALID_CLIENTS[5],
         RegisteredUrl::Semantic(
-            Url::from_str("https://auth.shad.moe/source/oauth/callback/purduehackers-id")
+            Url::from_str("https://auth.shad.moe/source/oauth/callback/purduehackers-id/")
                 .expect("url to be valid"),
         ),
         "user:read user".parse().expect("scopes to be valid"),


### PR DESCRIPTION
Add the Issuer (iss) and Subject (sub) fields to api/user.rs

This allows more compatibility with SSO Clients using OAuth.